### PR TITLE
Allow installation with python 3.11+

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -15,11 +15,6 @@ jobs:
   timeoutInMinutes: 360
 
   steps:
-  - script: |
-         rm -rf /opt/ghc
-         df -h
-    displayName: Manage disk space
-
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static
   - script: |

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos6
 channel_sources:

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ocefpaf
+* @ocefpaf @xylar

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -33,9 +33,9 @@ CONDARC
 
 
 mamba install --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/README.md
+++ b/README.md
@@ -1,13 +1,17 @@
-About backports-datetime-fromisoformat
-======================================
+About backports-datetime-fromisoformat-feedstock
+================================================
+
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/backports-datetime-fromisoformat-feedstock/blob/main/LICENSE.txt)
 
 Home: https://github.com/movermeyer/backports.datetime_fromisoformat
 
 Package license: MIT
 
-Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/backports-datetime-fromisoformat-feedstock/blob/main/LICENSE.txt)
-
 Summary: Backport of Python 3.11's datetime.fromisoformat
+
+Development: https://github.com/movermeyer/backports.datetime_fromisoformat
+
+Documentation: https://github.com/movermeyer/backports.datetime_fromisoformat/blob/main/README.rst
 
 Current build status
 ====================
@@ -144,4 +148,5 @@ Feedstock Maintainers
 =====================
 
 * [@ocefpaf](https://github.com/ocefpaf/)
+* [@xylar](https://github.com/xylar/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,8 @@ test:
   commands:
     - pip check
   requires:
+    # to make sure we're actually testing the backport
+    - python <3.11
     - pip
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ requirements:
   build:
     - {{ compiler('c') }}
   host:
-    - python  >=3.7
+    - python  >=3.7,<3.11
     - pip
   run:
     - python  >=3.7

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,7 @@ requirements:
   build:
     - {{ compiler('c') }}
   host:
+    # host needs python <3.11 so the backport actually gets built
     - python  >=3.7,<3.11
     - pip
   run:
@@ -30,7 +31,7 @@ test:
     - pip check
   requires:
     # to make sure we're actually testing the backport
-    - python <3.11
+    - python >=3.7,<3.11
     - pip
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,20 +12,20 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  number: 0
+  number: 1
 
 requirements:
   build:
     - {{ compiler('c') }}
   host:
-    - python  >=3.7,<3.11
+    - python  >=3.7
     - pip
   run:
-    - python  >=3.7,<3.11
+    - python  >=3.7
 
 test:
   imports:
-    - backports
+    - backports.datetime_fromisoformat
   commands:
     - pip check
   requires:
@@ -35,8 +35,12 @@ about:
   home: https://github.com/movermeyer/backports.datetime_fromisoformat
   summary: Backport of Python 3.11's datetime.fromisoformat
   license: MIT
+  license_family: MIT
   license_file: LICENSE
+  dev_url: https://github.com/movermeyer/backports.datetime_fromisoformat
+  doc_url: https://github.com/movermeyer/backports.datetime_fromisoformat/blob/main/README.rst
 
 extra:
   recipe-maintainers:
     - ocefpaf
+    - xylar

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+
+from datetime import date, datetime, time
+from backports.datetime_fromisoformat import MonkeyPatch
+MonkeyPatch.patch_fromisoformat()
+
+datetime.fromisoformat("2014-01-09T21:48:00-05:30")
+
+date.fromisoformat("2014-01-09")
+
+time.fromisoformat("21:48:00-05:30")

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -4,8 +4,8 @@ from datetime import date, datetime, time
 from backports.datetime_fromisoformat import MonkeyPatch
 MonkeyPatch.patch_fromisoformat()
 
-datetime.fromisoformat("2014-01-09T21:48:00-05:30")
+print(datetime.fromisoformat("2014-01-09T21:48:00-05:30"))
 
-date.fromisoformat("2014-01-09")
+print(date.fromisoformat("2014-01-09"))
 
-time.fromisoformat("21:48:00-05:30")
+print(time.fromisoformat("21:48:00-05:30"))


### PR DESCRIPTION
This will not cause any harm:
https://github.com/movermeyer/backports.datetime_fromisoformat#usage-in-python-311 https://github.com/movermeyer/backports.datetime_fromisoformat/blob/v2.0.0/backports/datetime_fromisoformat/__init__.py#L30

I have also added some more tests, made the import test more specific, added some info to the extras, and added myself as a maintainer.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

closes #11 
